### PR TITLE
Son/fix error response (again)

### DIFF
--- a/src/main/java/com/example/caboneftbe/controller/AuthenticateController.java
+++ b/src/main/java/com/example/caboneftbe/controller/AuthenticateController.java
@@ -1,6 +1,7 @@
 package com.example.caboneftbe.controller;
 
 import com.example.caboneftbe.enums.API_PARAMS;
+import com.example.caboneftbe.enums.Constants;
 import com.example.caboneftbe.request.ActiveUserRequest;
 import com.example.caboneftbe.request.LoginByEmailRequest;
 import com.example.caboneftbe.request.RefreshTokenRequest;
@@ -25,28 +26,28 @@ public class AuthenticateController {
     @PostMapping(API_PARAMS.LOGIN_BY_EMAIL)
     public ResponseEntity<ResponseObject> loginByEmail(@Valid @RequestBody LoginByEmailRequest request){
         return ResponseEntity.ok().body(
-                new ResponseObject("success", "Login successfully", authenticationService.loginByEmail(request))
+                new ResponseObject(Constants.RESPONSE_STATUS_SUCCESS, "Login successfully", authenticationService.loginByEmail(request))
         );
     }
 
     @PostMapping(API_PARAMS.REGISTER)
     public ResponseEntity<ResponseObject> register(@Valid @RequestBody RegisterRequest request){
         return ResponseEntity.ok().body(
-                new ResponseObject("success", "Register successfully", authenticationService.register(request))
+                new ResponseObject(Constants.RESPONSE_STATUS_SUCCESS, "Register successfully", authenticationService.register(request))
         );
     }
 
     @PostMapping(API_PARAMS.REFRESH_TOKEN)
     public ResponseEntity<ResponseObject> refreshToken(@RequestBody RefreshTokenRequest request){
         return ResponseEntity.ok().body(
-                new ResponseObject("success", "Refresh token successfully.", authenticationService.refreshToken(request))
+                new ResponseObject(Constants.RESPONSE_STATUS_SUCCESS, "Refresh token successfully.", authenticationService.refreshToken(request))
         );
     }
 
     @PutMapping(API_PARAMS.ACTIVE_USER)
     public ResponseEntity<ResponseObject> activeUser(@RequestBody ActiveUserRequest request){
         return ResponseEntity.ok().body(
-                new ResponseObject("success","Active user successfully", authenticationService.activeCode(request))
+                new ResponseObject(Constants.RESPONSE_STATUS_SUCCESS,"Active user successfully", authenticationService.activeCode(request))
         );
     }
 

--- a/src/main/java/com/example/caboneftbe/enums/Constants.java
+++ b/src/main/java/com/example/caboneftbe/enums/Constants.java
@@ -1,0 +1,6 @@
+package com.example.caboneftbe.enums;
+
+public class Constants {
+    public static final String RESPONSE_STATUS_ERROR = "Error";
+    public static final String RESPONSE_STATUS_SUCCESS = "Success";
+}

--- a/src/main/java/com/example/caboneftbe/exception/CustomExceptions.java
+++ b/src/main/java/com/example/caboneftbe/exception/CustomExceptions.java
@@ -1,5 +1,6 @@
 package com.example.caboneftbe.exception;
 
+import com.example.caboneftbe.enums.Constants;
 import lombok.*;
 import lombok.experimental.FieldDefaults;
 import org.springframework.http.HttpStatus;
@@ -17,7 +18,7 @@ public class CustomExceptions extends RuntimeException{
         return CustomExceptions.builder()
                 .status(HttpStatus.NOT_FOUND)
                 .error(ErrorResponse.builder()
-                        .status(HttpStatus.NOT_FOUND.getReasonPhrase())
+                        .status(Constants.RESPONSE_STATUS_ERROR)
                         .message(message)
                         .build())
                 .build();
@@ -26,7 +27,7 @@ public class CustomExceptions extends RuntimeException{
         return CustomExceptions.builder()
                 .status(HttpStatus.NOT_FOUND)
                 .error(ErrorResponse.builder()
-                        .status(HttpStatus.NOT_FOUND.getReasonPhrase())
+                        .status(Constants.RESPONSE_STATUS_ERROR)
                         .message(message)
                         .data(data)
                         .build())
@@ -37,7 +38,7 @@ public class CustomExceptions extends RuntimeException{
         return CustomExceptions.builder()
                 .status(HttpStatus.BAD_REQUEST)
                 .error(ErrorResponse.builder()
-                        .status(HttpStatus.BAD_REQUEST.getReasonPhrase())
+                        .status(Constants.RESPONSE_STATUS_ERROR)
                         .message(message)
                         .build())
                 .build();
@@ -46,7 +47,7 @@ public class CustomExceptions extends RuntimeException{
         return CustomExceptions.builder()
                 .status(HttpStatus.BAD_REQUEST)
                 .error(ErrorResponse.builder()
-                        .status(HttpStatus.BAD_REQUEST.getReasonPhrase())
+                        .status(Constants.RESPONSE_STATUS_ERROR)
                         .message(message)
                         .data(data)
                         .build())
@@ -57,7 +58,7 @@ public class CustomExceptions extends RuntimeException{
         return CustomExceptions.builder()
                 .status(HttpStatus.UNAUTHORIZED)
                 .error(ErrorResponse.builder()
-                        .status(HttpStatus.UNAUTHORIZED.getReasonPhrase())
+                        .status(Constants.RESPONSE_STATUS_ERROR)
                         .message(message)
                         .build())
                 .build();
@@ -67,7 +68,7 @@ public class CustomExceptions extends RuntimeException{
         return CustomExceptions.builder()
                 .status(HttpStatus.UNAUTHORIZED)
                 .error(ErrorResponse.builder()
-                        .status(HttpStatus.UNAUTHORIZED.getReasonPhrase())
+                        .status(Constants.RESPONSE_STATUS_ERROR)
                         .message(message)
                         .data(data)
                         .build())

--- a/src/main/java/com/example/caboneftbe/exception/CustomExceptions.java
+++ b/src/main/java/com/example/caboneftbe/exception/CustomExceptions.java
@@ -11,14 +11,24 @@ import org.springframework.http.HttpStatus;
 @Builder
 public class CustomExceptions extends RuntimeException{
     HttpStatus status;
-    CustomError error;
+    ErrorResponse error;
 
     public static CustomExceptions notFound(String message) {
         return CustomExceptions.builder()
                 .status(HttpStatus.NOT_FOUND)
-                .error(CustomError.builder()
-                        .code(String.valueOf(HttpStatus.NOT_FOUND.value()))
+                .error(ErrorResponse.builder()
+                        .status(HttpStatus.NOT_FOUND.getReasonPhrase())
                         .message(message)
+                        .build())
+                .build();
+    }
+    public static CustomExceptions notFound(String message, Object data) {
+        return CustomExceptions.builder()
+                .status(HttpStatus.NOT_FOUND)
+                .error(ErrorResponse.builder()
+                        .status(HttpStatus.NOT_FOUND.getReasonPhrase())
+                        .message(message)
+                        .data(data)
                         .build())
                 .build();
     }
@@ -26,9 +36,19 @@ public class CustomExceptions extends RuntimeException{
     public static CustomExceptions badRequest(String message) {
         return CustomExceptions.builder()
                 .status(HttpStatus.BAD_REQUEST)
-                .error(CustomError.builder()
-                        .code(String.valueOf(HttpStatus.BAD_REQUEST.value()))
+                .error(ErrorResponse.builder()
+                        .status(HttpStatus.BAD_REQUEST.getReasonPhrase())
                         .message(message)
+                        .build())
+                .build();
+    }
+    public static CustomExceptions badRequest(String message, Object data) {
+        return CustomExceptions.builder()
+                .status(HttpStatus.BAD_REQUEST)
+                .error(ErrorResponse.builder()
+                        .status(HttpStatus.BAD_REQUEST.getReasonPhrase())
+                        .message(message)
+                        .data(data)
                         .build())
                 .build();
     }
@@ -36,9 +56,20 @@ public class CustomExceptions extends RuntimeException{
     public static CustomExceptions unauthorized(String message) {
         return CustomExceptions.builder()
                 .status(HttpStatus.UNAUTHORIZED)
-                .error(CustomError.builder()
-                        .code(String.valueOf(HttpStatus.UNAUTHORIZED.value()))
+                .error(ErrorResponse.builder()
+                        .status(HttpStatus.UNAUTHORIZED.getReasonPhrase())
                         .message(message)
+                        .build())
+                .build();
+    }
+
+    public static CustomExceptions unauthorized(String message, Object data) {
+        return CustomExceptions.builder()
+                .status(HttpStatus.UNAUTHORIZED)
+                .error(ErrorResponse.builder()
+                        .status(HttpStatus.UNAUTHORIZED.getReasonPhrase())
+                        .message(message)
+                        .data(data)
                         .build())
                 .build();
     }

--- a/src/main/java/com/example/caboneftbe/exception/ErrorDetail.java
+++ b/src/main/java/com/example/caboneftbe/exception/ErrorDetail.java
@@ -1,17 +1,16 @@
 package com.example.caboneftbe.exception;
 
-
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import lombok.experimental.FieldDefaults;
 
 @Getter
 @Setter
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
-public class CustomError {
-    String code;
+public class ErrorDetail {
+    Object value;
     String message;
+    String path;
 }

--- a/src/main/java/com/example/caboneftbe/exception/ErrorResponse.java
+++ b/src/main/java/com/example/caboneftbe/exception/ErrorResponse.java
@@ -1,0 +1,18 @@
+package com.example.caboneftbe.exception;
+
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+
+@Getter
+@Setter
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class ErrorResponse {
+    String status;
+    String message;
+    Object data;
+}

--- a/src/main/java/com/example/caboneftbe/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/caboneftbe/exception/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ public class GlobalExceptionHandler {
         ex.getBindingResult().getFieldErrors().forEach(fieldError -> {
             errors.put(fieldError.getField(), ErrorDetail.builder()
                     .value(fieldError.getRejectedValue())
-                    .msg(fieldError.getDefaultMessage())
+                    .message(fieldError.getDefaultMessage())
                     .path(fieldError.getField())
                     .build());
         });

--- a/src/main/java/com/example/caboneftbe/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/caboneftbe/exception/GlobalExceptionHandler.java
@@ -24,7 +24,7 @@ public class GlobalExceptionHandler {
         });
 
         ErrorResponse response = ErrorResponse.builder()
-                .status("Failed")
+                .status("Error")
                 .message("Validation failed")
                 .data(errors)
                 .build();

--- a/src/main/java/com/example/caboneftbe/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/caboneftbe/exception/GlobalExceptionHandler.java
@@ -1,13 +1,49 @@
 package com.example.caboneftbe.exception;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
+        Map<String, ErrorDetail> errors = new HashMap<>();
+
+        ex.getBindingResult().getFieldErrors().forEach(fieldError -> {
+            errors.put(fieldError.getField(), ErrorDetail.builder()
+                    .value(fieldError.getRejectedValue())
+                    .msg(fieldError.getDefaultMessage())
+                    .path(fieldError.getField())
+                    .build());
+        });
+
+        ErrorResponse response = ErrorResponse.builder()
+                .status("Failed")
+                .message("Validation failed")
+                .data(errors)
+                .build();
+
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGlobalException(Exception ex) {
+        ErrorResponse response = ErrorResponse.builder()
+                .status("Error")
+                .message("Error")
+                .build();
+
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
     @ExceptionHandler(CustomExceptions.class)
-    public ResponseEntity<CustomError> handleGlobalException(CustomExceptions ex){
+    public ResponseEntity<ErrorResponse> handleGlobalException(CustomExceptions ex){
         return new ResponseEntity<>(ex.getError(), ex.getStatus());
     }
 }

--- a/src/main/java/com/example/caboneftbe/services/impl/AuthenticationServiceImpl.java
+++ b/src/main/java/com/example/caboneftbe/services/impl/AuthenticationServiceImpl.java
@@ -73,7 +73,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         // flow: lấy pw nhận vào -> encode -> nếu trùng với trong DB -> authen
         boolean isAuthenticated = passwordEncoder.matches(request.getPassword(), user.getPassword());
         if (!isAuthenticated) {
-            throw  CustomExceptions.unauthorized("Email or password didn't match!");
+            throw  CustomExceptions.unauthorized("Email or password wrong!");
         }
 
         String accessToken = jwtService.generateToken(user);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,14 +1,14 @@
 spring.application.name=caboneft-be
 
 # deployed db
-spring.datasource.url=jdbc:postgresql://cabonerf.postgres.database.azure.com:5432/cabonerf-be
-spring.datasource.username=postgres
-spring.datasource.password=Cabonerf2024
+#spring.datasource.url=jdbc:postgresql://cabonerf.postgres.database.azure.com:5432/cabonerf-be
+#spring.datasource.username=postgres
+#spring.datasource.password=Cabonerf2024
 
 # local db
-#spring.datasource.url=jdbc:postgresql://localhost:2345/cabonerf
-#spring.datasource.username=postgres
-#spring.datasource.password=12345
+spring.datasource.url=jdbc:postgresql://localhost:2345/cabonerf
+spring.datasource.username=postgres
+spring.datasource.password=12345
 
 spring.jpa.hibernate.ddl-auto= update
 spring.jpa.show-sql=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,15 @@
 spring.application.name=caboneft-be
 
+# deployed db
 spring.datasource.url=jdbc:postgresql://cabonerf.postgres.database.azure.com:5432/cabonerf-be
 spring.datasource.username=postgres
 spring.datasource.password=Cabonerf2024
+
+# local db
+#spring.datasource.url=jdbc:postgresql://localhost:2345/cabonerf
+#spring.datasource.username=postgres
+#spring.datasource.password=12345
+
 spring.jpa.hibernate.ddl-auto= update
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
error response now have this format:
{
"status": "Failed",
"message": "Validation failed",
"data": {
"password": {
"value": "",
"message": "must not be empty",
"path": "password"
},
"email": {
"value": "cabonerfgmail.com",
"message": "must be a well-formed email address",
"path": "email"
}
}
}